### PR TITLE
Add seo-analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`exporting-to-png`](resources/exporting-to-png/SKILL.md) - Export code snippets, diagrams, terminal output, or UI components to PNG images via headless browser or CLI tools.
 - [`prompt-engineering`](resources/prompt-engineering/SKILL.md) - Write effective LLM prompts — system prompts, few-shot examples, chain-of-thought, and structured output.
 - [`seo-auditing`](resources/seo-auditing/SKILL.md) - Audit technical SEO — meta tags, structured data, Open Graph, sitemaps, and Core Web Vitals.
+- [`seo-analysis`](https://github.com/nowork-studio/toprank/blob/main/seo/seo-analysis/SKILL.md) - Full SEO audit using Search Console, URL inspection, PageSpeed, technical crawling, metadata checks, schema review, and a prioritized 30-day action plan.
 - [`writing-copy`](resources/writing-copy/SKILL.md) - Write marketing copy for landing pages, CTAs, emails, microcopy, and product descriptions.
 
 ## Plugins


### PR DESCRIPTION
Adds `seo-analysis` under Utilities.

`seo-analysis` is an open-source SEO audit skill from `nowork-studio/toprank`. It combines Google Search Console data, URL inspection, PageSpeed Insights, technical crawling, metadata checks, and schema review to produce an actionable 30-day plan.

## Credibility
`nowork-studio/toprank` currently has **124 GitHub stars** and is MIT licensed.

## Why it fits
The repo already curates standalone `SKILL.md` resources, and `seo-analysis` is published as a dedicated skill file that users can adapt for Cursor-style skill workflows.

Source: https://github.com/nowork-studio/toprank/blob/main/seo/seo-analysis/SKILL.md
