### PR TITLE
Add Odoo ERP skills (new category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`vercel-composition-patterns`](https://github.com/vercel-labs/agent-skills/tree/main/skills/composition-patterns) - Component composition, code splitting, and server/client boundary patterns for Next.js.
 - [`react-native-patterns`](resources/react-native-patterns/SKILL.md) - Build mobile apps with React Native and Expo — navigation, platform-specific code, performance, and native modules.
 
+### ERP & Business Applications
+
+- [`odoo-model-inspect`](https://github.com/oconsole/odoo-skills/tree/master/odoo-model-inspect) - Inspect Odoo model structure, field definitions, view XML, and record counts (read-only).
+- [`odoo-accounting-inspect`](https://github.com/oconsole/odoo-skills/tree/master/odoo-accounting-inspect) - Inspect Odoo invoices, bills, payments, journal entries, and aged receivables (read-only).
+- [`odoo-mrp-inspect`](https://github.com/oconsole/odoo-skills/tree/master/odoo-mrp-inspect) - Inspect Odoo manufacturing orders, bills of materials, production status, and component availability (read-only).
+- [`odoo-stock-inspect`](https://github.com/oconsole/odoo-skills/tree/master/odoo-stock-inspect) - Inspect Odoo inventory levels, stock moves, transfers, and reordering rules (read-only).
+- [`odoo-system-inspect`](https://github.com/oconsole/odoo-skills/tree/master/odoo-system-inspect) - Inspect Odoo system health including modules, cron jobs, error logs, and user activity (read-only).
+- [`odoo-model-customize`](https://github.com/oconsole/odoo-skills/tree/master/odoo-model-customize) - Customize Odoo models at runtime — custom fields, views, defaults, filters, and automated actions.
+- [`odoo-model-customize-demo`](https://github.com/oconsole/odoo-skills/tree/master/odoo-model-customize-demo) - Sandboxed Odoo customization for learning and prototyping with demo-tagged artifacts for easy cleanup.
+
 ### Planning & Architecture
 
 - [`mattpocock-prd-to-issues`](https://github.com/mattpocock/skills/tree/main/prd-to-issues) - Convert a product requirements doc into a set of well-scoped GitHub issues.


### PR DESCRIPTION
## Summary

- Add new **ERP & Business Applications** category with 7 Odoo ERP skills
- 5 read-only inspection skills covering models, accounting, manufacturing, inventory, and system health
- 2 write-tier skills for runtime model customization (production + sandboxed demo mode)
- All skills use the standard SKILL.md format and require an Odoo MCP server

## Skills added

| Skill | Purpose |
|---|---|
| `odoo-model-inspect` | Model structure, fields, views, record counts |
| `odoo-accounting-inspect` | Invoices, bills, payments, journal entries |
| `odoo-mrp-inspect` | Manufacturing orders, BoMs, production status |
| `odoo-stock-inspect` | Inventory levels, stock moves, warehouse transfers |
| `odoo-system-inspect` | Modules, cron jobs, error logs, user activity |
| `odoo-model-customize` | Custom fields, views, defaults, filters, automations |
| `odoo-model-customize-demo` | Sandboxed version with demo tagging for cleanup |

## Quality

- Verified on Odoo 18 and 19
- Auto-curated pitfall lists via [RL pipeline](https://github.com/oconsole/odoo-skills-rl) — 70% error reduction
- Each SKILL.md includes version-specific compatibility tables

## New category justification

Per CONTRIBUTING.md, new categories need at least 3 entries. This PR adds 7 skills under "ERP & Business Applications" — a domain not currently represented in the list.

Source: [github.com/oconsole/odoo-skills](https://github.com/oconsole/odoo-skills) (MIT)