### PR TITLE
Add HTML to PDF conversion skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 ### Utilities
 
 - [`exporting-to-png`](resources/exporting-to-png/SKILL.md) - Export code snippets, diagrams, terminal output, or UI components to PNG images via headless browser or CLI tools.
+- [`html-to-pdf`](https://github.com/jamesxjz/html-to-pdf-agent-skill) - Convert remote HTML pages to PDF with intelligent SPA detection, full documentation crawling, and multi-page merging.
 - [`prompt-engineering`](resources/prompt-engineering/SKILL.md) - Write effective LLM prompts — system prompts, few-shot examples, chain-of-thought, and structured output.
 - [`seo-auditing`](resources/seo-auditing/SKILL.md) - Audit technical SEO — meta tags, structured data, Open Graph, sitemaps, and Core Web Vitals.
 - [`seo-analysis`](https://github.com/nowork-studio/toprank/blob/main/seo/seo-analysis/SKILL.md) - Full SEO audit using Search Console, URL inspection, PageSpeed, technical crawling, metadata checks, schema review, and a prioritized 30-day action plan.


### PR DESCRIPTION
## Summary

Adds a universal Agent Skill for converting HTML pages to PDF files.

## Features

- 🚀 **Intelligent SPA detection** - Automatically waits for JavaScript to render before extraction
- 📄 **Full documentation crawling** - Extracts real navigation links from sidebars (no URL guessing)
- 🔗 **Multi-page merging** - Combines all documentation pages into a single PDF
- 🎨 **Custom styling** - Supports authentication, custom CSS, and page formatting
- ✅ **Production-tested** - Successfully converted Cursor, DeepSeek, and AgentSkills official documentation

## Compatibility

Compatible with Cursor, Claude Code, GitHub Copilot, VS Code, and 30+ Agent Skills-enabled tools following the [Agent Skills open standard](https://agentskills.io/).

## Repository

https://github.com/jamesxjz/html-to-pdf-agent-skill

## Test Cases

- ✅ Cursor API documentation (96 pages → 217-page PDF)
- ✅ Cursor Chinese docs (38 chapters → 192-page PDF)
- ✅ DeepSeek API docs (18 chapters → 50-page PDF)
- ✅ AgentSkills documentation (11 chapters → 65-page PDF)

## Category

Added to the **Utilities** section as it's a general-purpose tool for document processing.