### PR TITLE
docs: add Taubyte skills repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`setting-up-terraform`](resources/setting-up-terraform/SKILL.md) - Infrastructure-as-code with provider config, modules, remote state, and CI integration.
 - [`antonbabenko-terraform`](https://github.com/antonbabenko/terraform-skill) - Terraform and OpenTofu skill — testing, modules, CI/CD, and production patterns.
 - [`kubernetes-deploying`](resources/kubernetes-deploying/SKILL.md) - Deploy to Kubernetes — Deployments, Services, Ingress, ConfigMaps, health checks, and autoscaling.
+- [Taubyte](https://github.com/taubyte/skills) - Cursor agent skills for the Taubyte cloud platform — functions, websites, deployment, and local Dream development.
 
 ### Code Quality & Security
 


### PR DESCRIPTION
Adds [Taubyte](https://github.com/taubyte/skills) to the Infrastructure & DevOps section — Cursor agent skills for the Taubyte cloud platform.

Made with [Cursor](https://cursor.com)