### PR TITLE
Add Superpower Builder to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Official Cursor marketplace plugins with bundled skills. Install via **Cursor Se
 - [Meta Reality Labs](https://cursor.com/cn/marketplace/meta-reality-labs) - (`hz-immersive-designer`, `hz-new-project-creation` + 11 more) Quest and Horizon OS development.
 - [Plain](https://cursor.com/cn/marketplace/plain) - Support threads, customer management, and help center articles.
 - [Turbopuffer](https://cursor.com/cn/marketplace/turbopuffer) - Vector and full-text search database integration.
+- [Superpower Builder](https://github.com/redhuntlabs/superpower-builder) - Interview-driven meta-builder that turns recurring tasks into reusable `SKILL.md` files, routed by kind (workflow, discipline, content, subagent) with baseline-vs-with-skill pressure-testing on each generated skill. Ships 25 bundled superpowers covering dev (TDD, plan/execute) and non-dev (research, writing, decisions) work. Installs via Cursor plugin descriptor (`.cursor-plugin/plugin.json`).
 
 ## Cursor Resources
 


### PR DESCRIPTION
## What this adds

Adds [Superpower Builder](https://github.com/redhuntlabs/superpower-builder) to the Plugins section.

It's an interview-driven meta-builder for `SKILL.md` files. Differentiator vs other entries: **kind-routing** (workflow / discipline / content / subagent) runs a different specialist interview per kind, and every generated skill is **pressure-tested** baseline-without-skill vs. with-skill before being saved — so behavioral change is demonstrated, not assumed.

Ships 25 hand-crafted superpowers across dev work (TDD, plan/execute, brainstorming) and non-dev work (research, writing, decisions, daily tasks), plus the meta-builder itself.

## Format checklist

- [x] Entry uses the standard format and ends with a period
- [x] Added to the bottom of the Plugins category
- [x] Link is working
- [x] One PR, one addition
- [x] Has clear documentation (full README + docs/) and a `SKILL.md` per superpower
- [x] Compatible with Cursor — ships `.cursor-plugin/plugin.json` and skills load via Cursor's standard skills directory
- [x] Actively maintained (V1.0.0 just shipped; MIT)