### PR TITLE
Add concise skill to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`seo-auditing`](resources/seo-auditing/SKILL.md) - Audit technical SEO — meta tags, structured data, Open Graph, sitemaps, and Core Web Vitals.
 - [`seo-analysis`](https://github.com/nowork-studio/toprank/blob/main/seo/seo-analysis/SKILL.md) - Full SEO audit using Search Console, URL inspection, PageSpeed, technical crawling, metadata checks, schema review, and a prioritized 30-day action plan.
 - [`writing-copy`](resources/writing-copy/SKILL.md) - Write marketing copy for landing pages, CTAs, emails, microcopy, and product descriptions.
+- [`concise`](https://github.com/Cpp1022/concise) - Chinese-first concise mode skill. Compresses Cursor agent replies on two layers (expression + content) with auto-relax for safety, multi-step, and parameter-heavy cases. Works across Cursor, Claude Code, and Codex CLI.
 
 ## Plugins
 


### PR DESCRIPTION
## What

Adds [`concise`](https://github.com/Cpp1022/concise) to **Skills → Utilities**, at the bottom of the category.

## Description

Chinese-first concise mode skill. Compresses Cursor agent replies on two layers (expression + content) with auto-relax for safety, multi-step, and parameter-heavy cases. Works across Cursor, Claude Code, and Codex CLI from a single source.

## Follows CONTRIBUTING

- ✅ Entry format: `- [\`name\`](link) - description ending with period.`
- ✅ Added to the bottom of an existing category (Utilities) — parallel to `prompt-engineering` and `writing-copy`
- ✅ Has `SKILL.md`, Cursor-compatible (`.cursor/skills/concise/SKILL.md`)
- ✅ One PR, one addition
- ✅ Links verified

## Why it's more than "a wrapper around a single prompt"

- Two explicit modes (`lite` = expression only, `ultra` = expression + content)
- Auto-relax logic for safety, multi-step instructions, parameter-heavy explanations
- Cross-agent packaging (Claude Code / Codex CLI / Cursor) with one-line installer
- Ships a companion `concise-default` skill that flips the default on for every new chat

— Cyy

Made with [Cursor](https://cursor.com)