### PR TITLE
Add ChatCrystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`writing-commit-messages`](resources/writing-commit-messages/SKILL.md) - Write conventional commit messages with type prefixes, scopes, and meaningful descriptions.
 - [`incident-response`](resources/incident-response/SKILL.md) - Handle production incidents — triage severity, mitigate, communicate status, and write blameless postmortems.
 - [`systematic-debugging`](resources/systematic-debugging/SKILL.md) - Structured debugging methodology — reproduce, isolate, hypothesize, and verify using git bisect, binary search, and logging.
+- [`chatcrystal`](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills) - Local-first memory recall and writeback skills for AI coding sessions via ChatCrystal Core and MCP.
 
 ### Infrastructure & DevOps
 


### PR DESCRIPTION
Adds ChatCrystal to the Workflow category.

ChatCrystal provides local-first memory recall and writeback skills for AI coding sessions via ChatCrystal Core and MCP.

Validation:
- Public repo exposes three installable Agent Skills via `npx skills add ZengLiangYi/ChatCrystal --list`.