### PR TITLE
Add Skills宝 directory entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Cursor Rules (`.cursorrules` / `.cursor/rules/`) are complementary to skills —
 - [skills.sh](https://skills.sh/) - Leaderboard and directory for popular skill repositories.
 - [AgentDepot.dev](https://agentdepot.dev/) - Open-source explorer for agents, skills, and rules.
 - [CursorDirectory](https://cursor.directory/) - Community directory for Cursor rules and configurations.
+- [Skills宝](https://skilery.com) - Chinese search and installation directory for AI skills across Cursor, Claude Code, OpenCode, and other agent tools.
 
 ### Tools
 


### PR DESCRIPTION
Add Skills宝 (skilery.com) as a Chinese search and installation directory for AI skills in the Directories section.

This aligns with the repo's existing discovery resources like skills.sh, AgentDepot.dev, and CursorDirectory.