### PR TITLE
Add dependabot-triage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 ### Dependencies
 
 - [`updating-npm-package`](resources/updating-npm-package/SKILL.md) - Safely update an npm package: check npmjs.com for the latest version, read release notes, auto-apply minor updates, and for major updates find the migration guide and produce a detailed validation report.
+- [`dependabot-triage`](https://github.com/akshayrao14/git-practices/tree/main/skills/dependabot-triage) - Defensive Dependabot triage for JS/TS repos (npm, pnpm, yarn, bun) — picks the *minimal* patched version that supersets every CVE in the cluster, maps every import site into Public/API · Client-Bundle · Internal/Dev exposure buckets, enforces npm↔pnpm lockfile parity before opening the PR, and scrapes the changelog for `BREAKING` / `DEPRECATED` / `MIGRATION` keywords with a safety interlock. Standard and Fast-Track modes. Cross-agent (Cursor, Claude Code, Codex CLI).
 
 ### Frontend & UI
 


### PR DESCRIPTION
## What

Adds [`dependabot-triage`](https://github.com/akshayrao14/git-practices/tree/main/skills/dependabot-triage) under **Dependencies** — right next to \`updating-npm-package\`, since it's effectively the security-driven counterpart.

## Why

\`updating-npm-package\` covers proactive version bumps. This one covers *security-driven* bumps (Dependabot alerts), where the failure modes are different — wrong-version regressions, partially-patched lockfiles, and changelog blind spots.

Differentiated approach vs generic bump-and-PR autofix:

- **Minimal-patched versioning** — picks the smallest version that supersets every CVE patch in the cluster, not \`latest-in-major\`. Smaller change surface, lower regression risk.
- **Exposure mapping** — every import site bucketed into Public/API · Client-Bundle · Internal/Dev. Replaces heuristic "is it reachable" guessing.
- **Mandatory lockfile parity check** between \`package-lock.json\` and \`pnpm-lock.yaml\`. Aborts the PR on mismatch (the exact class of bug where CI runs npm and dev runs pnpm and only one path got patched).
- **Changelog scrape with safety interlock** — flags \`BREAKING\` / \`DEPRECATED\` / \`MIGRATION\` and pauses for explicit user confirmation before applying the bump.
- **Standard** (full defensive) and **Fast-Track** (low-risk Internal/Dev or CVSS<7) modes. Fast-Track auto-reverts to Standard on parity or build failure.

Lockfile coverage: npm, pnpm, yarn, bun. Browser frontends + Node.js services.

## Cursor compatibility

Skill follows the SKILL.md open standard — drops into \`.cursor/skills/dependabot-triage/\` per project. Install instructions in the skill README cover the Cursor path explicitly.

## Compliance

- Open-source, MIT licensed, no SaaS dependency or paid backend.
- Tagged release: [v2.1.1](https://github.com/akshayrao14/git-practices/releases/tag/v2.1.1).
- Listed on [skills.sh](https://skills.sh/akshayrao14/git-practices).
- One item per PR.

## Format

Single bullet added to the **Dependencies** section, matching existing format.