### PR TITLE
Add @hanv89/azure-arch-skill — Azure & Fabric architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`anthropic-mcp-builder`](https://github.com/anthropics/skills/tree/main/skills/mcp-builder) - Build Model Context Protocol servers from scratch with tool definitions and transport setup.
 - [`architecture-decision-records`](resources/architecture-decision-records/SKILL.md) - Document technical decisions as ADRs with context, options considered, and rationale.
 - [`database-design`](resources/database-design/SKILL.md) - Design database schemas — tables, relationships, indexes, constraints, and ORM setup.
+- [`@hanv89/azure-arch-skill`](https://github.com/hanv89/azure-icons-for-architecture-diagrams) - Draw Microsoft Azure and Microsoft Fabric architecture diagrams in PlantUML with `<img:URL>` references to 840 first-party-MIT icons; per-vendor `INDEX.md` lets the agent grep by name/tag instead of guessing filenames. Install: `npx @hanv89/azure-arch-skill@latest install --agent=cursor` (per-project install into `<cwd>/.cursor/rules/`).
 
 ### Documentation
 


### PR DESCRIPTION
Adding `@hanv89/azure-arch-skill` under **Planning & Architecture** (one PR, one entry, per CONTRIBUTING).

## What

A skill (Claude Code, Codex CLI, Cursor) that teaches the agent to draw Microsoft Azure and Microsoft Fabric architecture diagrams in PlantUML, using literal `<img:URL>` references to 840 first-party-MIT icons:
- 528 Azure icons from `plantuml-stdlib/Azure-PlantUML`.
- 312 Microsoft Fabric icons from `@fabric-msft/svg-icons`.

The Cursor install model is **per-project** — `npx @hanv89/azure-arch-skill@latest install --agent=cursor` writes to `<current working directory>/.cursor/rules/azure-arch-skill.mdc`, which is intentional (Cursor rules are workspace-scoped). Pass `--target=<path>` to override.

## Quality checklist (CONTRIBUTING)

- ✅ Actively maintained: weekly upstream-sync cron with health monitors gating any refresh; current release `v1.1.0` (2026-05-16).
- ✅ Clear documentation: README + bundled `SKILL.md` with worked examples, install/uninstall, Cursor cwd callout, troubleshooting, project status.
- ✅ Cursor-compatible: ships `.mdc` rule file via the per-project install model.
- ✅ Genuine value: not a single-prompt wrapper. Bundles 6 worked `.puml` examples + per-vendor `INDEX.md` for icon discovery; v1.1.0 specifically solves the *"agent guesses the wrong filename"* failure mode.

## Links

- Repo: https://github.com/hanv89/azure-icons-for-architecture-diagrams
- npm: https://www.npmjs.com/package/@hanv89/azure-arch-skill/v/1.1.0
- License: MIT (code); icons under Microsoft Trademark Guidelines + Azure/Fabric icon Terms of Use.