### PR TITLE
add authsome under Authentication &amp; Payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 
 - [`adding-auth`](resources/adding-auth/SKILL.md) - Add OAuth login, session management, and protected routes with Auth.js (NextAuth).
 - [`adding-stripe`](resources/adding-stripe/SKILL.md) - Integrate Stripe checkout, subscriptions, webhooks, and customer portal.
+- [`authsome`](https://github.com/agentrhq/authsome) - Local credential broker for AI agents. Log in once via OAuth2 or API key, encrypted vault stores credentials, local proxy injects them at request time so Cursor's agent never sees raw secrets. 45 providers bundled including GitHub, Google, OpenAI, Linear, Slack, Notion, Resend, Stripe.
 
 ### Testing
 


### PR DESCRIPTION
hey, opening this to add authsome under Authentication & Payments, right next to `adding-auth`.

authsome is a local credential broker for AI agents (cursor included). log in once via OAuth2 or API key, encrypted vault stores credentials, a local proxy injects them at request time so the cursor agent never touches raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe.

different focus than `adding-auth` (which scaffolds Auth.js into a project). authsome is runtime infra for the agent itself — keeps the agent's outbound API calls authenticated without secrets ending up in the process env or in conversation context.

ships SKILL.md, works in cursor following the standard cursor skill loading. happy to reword or move it.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT