### PR TITLE
Add four-leaf-coach skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`seo-analysis`](https://github.com/nowork-studio/toprank/blob/main/seo/seo-analysis/SKILL.md) - Full SEO audit using Search Console, URL inspection, PageSpeed, technical crawling, metadata checks, schema review, and a prioritized 30-day action plan.
 - [`writing-copy`](resources/writing-copy/SKILL.md) - Write marketing copy for landing pages, CTAs, emails, microcopy, and product descriptions.
 - [`concise`](https://github.com/Cpp1022/concise) - Chinese-first concise mode skill. Compresses Cursor agent replies on two layers (expression + content) with auto-relax for safety, multi-step, and parameter-heavy cases. Works across Cursor, Claude Code, and Codex CLI.
+- [`four-leaf-coach`](https://github.com/fourleafai/clover-public) - Job search and interview prep coach backed by a hosted MCP server. Live job search across 180k+ active postings, role-calibrated practice questions for 24 roles, resume scoring against a JD, comp negotiation. Install with `npx four-leaf-coach add`.
 
 ## Plugins
 


### PR DESCRIPTION
Adds `four-leaf-coach` to the Utilities section.

**Skill:** Job search and interview prep coach backed by a hosted MCP server.

**Repo:** https://github.com/fourleafai/clover-public (MIT, actively maintained)

**What it does:**
- Live job search across 180k+ active postings (Greenhouse, Lever, Ashby, Workday)
- Role-calibrated practice questions for 24 roles
- Resume scoring against a specific JD
- Comp negotiation coaching with cited market data

**Install:** `npx four-leaf-coach add` (Cursor, Claude Code, Codex CLI, Copilot)

Filed under Utilities since there's no Career category yet and CONTRIBUTING requires 3 entries to propose a new one. Happy to move if there's a better fit.