### PR TITLE
Add TWZRD Agent Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 
 - [`reviewing-code`](resources/reviewing-code/SKILL.md) - Thorough code review focused on correctness, maintainability, performance, and best practices.
 - [`auditing-security`](resources/auditing-security/SKILL.md) - Systematic security audit checking for OWASP Top 10 vulnerabilities, secrets exposure, and insecure patterns.
+- [`twzrd-agent-intel`](https://intel.twzrd.xyz) - Pre-dispatch trust gating for AI agents on Solana. MCP tools: resolve_agent, score_agent, preflight_check, verify_trust_receipt (free) and get_trust_receipt (paid via x402). Zero-install remote MCP: `https://intel.twzrd.xyz/mcp`.
 - [`auditing-performance`](resources/auditing-performance/SKILL.md) - Audit bundle size, rendering, database queries, and Core Web Vitals.
 - [`sentry-code-simplifier`](https://github.com/getsentry/skills/tree/main/plugins/sentry-skills/skills/code-simplifier) - Refactor for clarity, consistency, and maintainability — eliminates dead code, fixes naming, and reduces complexity.
 - [`sentry-find-bugs`](https://github.com/getsentry/skills/tree/main/plugins/sentry-skills/skills/find-bugs) - Scan local branch changes for bugs, security vulnerabilities, and code quality issues.


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) under **Code Quality & Security** — an MCP server for pre-dispatch trust gating of AI agents on Solana. Useful for Cursor agent workflows that interact with external AI agents or on-chain services.

Zero-install config:
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

**Free tools:** `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`
**Paid:** `get_trust_receipt` (x402, <1s Solana USDC settlement)

- Website: https://intel.twzrd.xyz
- PyPI: https://pypi.org/project/twzrd-agent-intel/