### PR TITLE
Add Developer Marketing Skills section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`writing-copy`](resources/writing-copy/SKILL.md) - Write marketing copy for landing pages, CTAs, emails, microcopy, and product descriptions.
 - [`concise`](https://github.com/Cpp1022/concise) - Chinese-first concise mode skill. Compresses Cursor agent replies on two layers (expression + content) with auto-relax for safety, multi-step, and parameter-heavy cases. Works across Cursor, Claude Code, and Codex CLI.
 
+### Developer Marketing Skills
+- [Infrasity-Labs/dev-gtm-claude-skills](https://github.com/Infrasity-Labs/dev-gtm-claude-skills) by [Infrasity-Labs](https://github.com/Infrasity-Labs) - Open-source, cross-platform agent skills for Claude Code and agentskills.io-compatible platforms. These skills are for SEO, GEO (Generative Engine Optimization), AI discoverability, and developer marketing. 
+
 ## Plugins
 
 Official Cursor marketplace plugins with bundled skills. Install via **Cursor Settings > Plugins**.


### PR DESCRIPTION
Added developer marketing skills to the readme section. These skills are made for AEO, GEO, and AI Visibility

Add the dev-gtm-claude-skills repo to your community skills. These are agent skills for developer marketing workflows, AEO, GEO and AI Visibility

# Pull Request: Add Skill

## Skill Information

- **Skill Name:** dev-gtm-claude-skills
- **Category:** Developer Marketing
- **Repository URL:** https://github.com/Infrasity-Labs/dev-gtm-claude-skills
- **I am the author of this skill:** [x] Yes [ ] No

## Quality Checklist

Please verify that your submission meets these requirements:

- [x] Has working `SKILL.md` file with YAML frontmatter
- [x] Clear, concise documentation
- [x] Active maintenance (commits within last 6 months)
- [x] Relevant to Cursor workflows
- [x] No security vulnerabilities or malicious code
- [x] All links are valid and working
- [x] Includes specific use case

## Skill Entry
- [Infrasity-Labs/dev-gtm-claude-skills](https://github.com/Infrasity-Labs/dev-gtm-claude-skills)  - Open-source, cross-platform agent skills for Claude Code and agentskills.io-compatible platforms. These skills are for SEO, GEO (Generative Engine Optimization), AI discoverability, and developer marketing. 

## Why This Skill is Valuable

These skills automate the tedious, repetitive parts of developer GTM work like auditing doc metadata, checking AI discoverability, and validating content structure, freeing developer marketing teams to focus on strategy instead of manually checking hundreds of pages.

## Testing

- [x] I have tested this skill with Cursor
- [x] The skill works as described
- [x] Installation instructions are clear

---

**By submitting this PR, I confirm that:**
- This contribution is my own work or I have the right to submit it