### PR TITLE
Add EDC repo-context tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Cursor Rules (`.cursorrules` / `.cursor/rules/`) are complementary to skills —
 
 - [npx skills](https://github.com/vercel-labs/skills) - CLI to search, install, and manage skills.
 - [PostHog/context-mill](https://github.com/PostHog/context-mill) - Assemble context for AI agents into Agent Skills-compliant packages.
+- [EDC](https://github.com/almogdepaz/EDC) - Local repo-context generator that installs Cursor-compatible commands and skills for context-aware review/audit workflows across large repositories.
 - [Anthropic Skill Creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Official skill for drafting, testing, and optimizing custom SKILL.md files.
 
 ---


### PR DESCRIPTION
## Summary
- Add EDC under Cursor Resources > Tools
- Describe its Cursor-compatible commands/skills for repo-context review and audit workflows

EDC also supports Claude Code, Codex, and pi.