### PR TITLE
Add penthera to Code Quality & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`sentry-skill-scanner`](https://github.com/getsentry/skills/tree/main/plugins/sentry-skills/skills/skill-scanner) - Scan agent skills for security issues — prompt injection, exfiltration, and unsafe tool use.
 - [`verifying-markdown-formatting`](resources/verifying-markdown-formatting/SKILL.md) - Verify headings, lists, links, code blocks, spacing, and style consistency in Markdown files.
 - [`fixing-broken-links`](resources/fixing-broken-links/SKILL.md) - Crawl all URLs in a file, test each for HTTP 200, and fix or replace any broken links.
+- [`penthera`](https://github.com/danoszz/penthera/tree/main/skills/penthera) - Security scanner for web apps covering TLS, headers, auth hardening, secret scanning, IDOR/OAuth, and injection probes, with OWASP-mapped findings and SARIF output. Runs as a Cursor skill or CLI for authorized testing only.
 
 ### Dependencies
 


### PR DESCRIPTION
Adds **Penthera** to the **Code Quality & Security** category (one entry, at the bottom of the section, per the contributing guidelines).

Penthera is an open-source security scanner that runs as a Cursor skill (and Claude Code, and a CLI). It covers TLS, security headers, auth hardening, secret scanning, IDOR/OAuth, and injection probes, maps findings to OWASP WSTG, and exports SARIF.

Quality checklist:
- Actively maintained (released this week, MIT)
- Has a `SKILL.md`: https://github.com/danoszz/penthera/tree/main/skills/penthera
- Cursor-compatible (installs to `.cursor/skills/`)
- Genuine value (full scanner, not a single-prompt wrapper)

Install: `npx skills add danoszz/penthera`
