### PR TITLE
Add Skill Hub — 5800+ AI Agent Skills Navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Cursor Rules (`.cursorrules` / `.cursor/rules/`) are complementary to skills —
 
 ---
 
+- [Skill Hub](https://skill.442595.xyz/) — 5800+ curated AI Agent Skills for Claude Code, Codex, Cursor, Hermes & more across 22 categories.
 ## Contributing
 
 Contributions welcome! Please read the [contribution guidelines](CONTRIBUTING.md) first.


### PR DESCRIPTION
Add [Skill Hub](https://skill.442595.xyz/) — a free directory of 5800+ curated AI agent skills for Claude Code, Codex, Cursor, Hermes, OpenClaw & more across 22 categories.