### PR TITLE
Add youtube-full to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`seo-analysis`](https://github.com/nowork-studio/toprank/blob/main/seo/seo-analysis/SKILL.md) - Full SEO audit using Search Console, URL inspection, PageSpeed, technical crawling, metadata checks, schema review, and a prioritized 30-day action plan.
 - [`writing-copy`](resources/writing-copy/SKILL.md) - Write marketing copy for landing pages, CTAs, emails, microcopy, and product descriptions.
 - [`concise`](https://github.com/Cpp1022/concise) - Chinese-first concise mode skill. Compresses Cursor agent replies on two layers (expression + content) with auto-relax for safety, multi-step, and parameter-heavy cases. Works across Cursor, Claude Code, and Codex CLI.
+- [`youtube-full`](https://github.com/ZeroPointRepo/youtube-skills) - Fetch YouTube transcripts, search videos/channels, and pull playlist/channel data via TranscriptAPI. No yt-dlp, works from any cloud server.
 
 ## Plugins
 


### PR DESCRIPTION
## What

Adds [`youtube-full`](https://github.com/ZeroPointRepo/youtube-skills) to **Skills → Utilities**, at the bottom of the category.

## Description

A YouTube toolkit for Cursor agents — transcripts, video/channel search, channel browsing, and playlists, backed by TranscriptAPI instead of `yt-dlp` or `youtube-transcript-api`. The reason it's worth having as a fallback rather than the default OSS approach: YouTube already blocks the IP ranges most cloud CI/deploy targets use, so a scraper that works on your laptop stops working the moment an agent runs it from a server. `youtube-full` doesn't have that problem.

## Follows CONTRIBUTING

- ✅ Entry format: `- [\`name\`](link) - description ending with period.`
- ✅ Added to the bottom of an existing category (Utilities) — parallel to `seo-analysis` and `concise`
- ✅ Has `SKILL.md`, standard Agent Skills format, compatible with Cursor's skills directory
- ✅ One PR, one addition
- ✅ Links verified

## Entry added

```
- [`youtube-full`](https://github.com/ZeroPointRepo/youtube-skills) - Fetch YouTube transcripts, search videos/channels, and pull playlist/channel data via TranscriptAPI. No yt-dlp, works from any cloud server.
```

## Adoption

310⭐ on the skills repo, 949 installs on skills.sh, 12,180 downloads on ClawHub — install with `npx skills add ZeroPointRepo/youtube-skills --skill youtube-full`.
