### PR TITLE
Add gpu-brrr: GPU performance diagnosis skill (ML and AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`writing-copy`](resources/writing-copy/SKILL.md) - Write marketing copy for landing pages, CTAs, emails, microcopy, and product descriptions.
 - [`concise`](https://github.com/Cpp1022/concise) - Chinese-first concise mode skill. Compresses Cursor agent replies on two layers (expression + content) with auto-relax for safety, multi-step, and parameter-heavy cases. Works across Cursor, Claude Code, and Codex CLI.
 
+### Machine Learning & AI
+
+- [`gpu-brrr`](https://github.com/tripplen23/gpu-brrr) - Diagnose GPU bottlenecks from first principles: classify compute-bound vs bandwidth-bound vs overhead-bound, then apply the matching fix. Supports PyTorch profiling, `torch.compile`, Nsight, Triton kernels, and roofline analysis.
+
 ## Plugins
 
 Official Cursor marketplace plugins with bundled skills. Install via **Cursor Settings > Plugins**.


### PR DESCRIPTION
## Summary

Adds [GPU Brrr](https://github.com/tripplen23/gpu-brrr) — a measurement-first GPU performance optimization skill for deep learning workloads.

## What it does

- Diagnoses *why* a PyTorch workload is slow before applying any fix
- Classifies bottlenecks: compute-bound vs bandwidth-bound vs overhead-bound
- Applies the matching fix only (not blind optimization)
- Covers `torch.compile`, kernel fusion, mixed precision, CUDA Graphs, Nsight profiling, roofline analysis, and Triton kernels
- Based on Horace He's seminal article "Making Deep Learning Go Brrrr From First Principles"

## How to install

```bash
npx skills add tripplen23/gpu-brrr
```

Or manually: copy `skills/gpu-brrr` into `.cursor/skills/`.

## New category

Added as the first entry in a new **Machine Learning & AI** category. ML engineers are adopting agent skills for profiling, training optimization, and model debugging.

## Compatibility

- ✅ Cursor (`.cursor/skills/` auto-discovery)
- ✅ Claude Code (Claude plugin marketplace)
- ✅ Kiro (`kiro skill install`)
- ✅ Codex CLI
- ✅ Any agent supporting the Agent Skills standard
