### PR TITLE
Add UIZZE AI UI slop review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`vercel-react-view-transitions`](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions) - Implement the View Transitions API in React/Next.js for smooth page and component animations.
 - [`vercel-composition-patterns`](https://github.com/vercel-labs/agent-skills/tree/main/skills/composition-patterns) - Component composition, code splitting, and server/client boundary patterns for Next.js.
 - [`react-native-patterns`](resources/react-native-patterns/SKILL.md) - Build mobile apps with React Native and Expo — navigation, platform-specific code, performance, and native modules.
+- [`ai-ui-slop-review`](https://github.com/aislon/uizze-mcp/tree/main/skills/ai-ui-slop-review) - Review rendered web and iOS interfaces for evidence-backed blockers, missing states, responsive or accessibility gaps, and generic product decisions before calling the UI done.
 
 ### Planning & Architecture
 


### PR DESCRIPTION
## What changed

- Added the `ai-ui-slop-review` skill to Frontend & UI.
- Linked directly to its maintained `SKILL.md` directory.

## Why

The skill gives Cursor a review-only finish gate for rendered web and iOS interfaces: it checks product specificity, hierarchy, interaction states, observable responsive/accessibility gaps, and design-system drift without claiming subjective taste as fact.

I build UIZZE (https://uizze.com), which publishes and maintains the skill. It is tool-agnostic, compatible with Cursor, documented, MIT-licensed, and installable through the Agent Skills CLI.

## Validation

- Confirmed there is no existing UIZZE entry.
- Confirmed the linked skill returns HTTP 200.
- Ran `git diff --check`.
