### PR TITLE
feat: add UIZZE UI finish-gate skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`vercel-react-view-transitions`](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions) - Implement the View Transitions API in React/Next.js for smooth page and component animations.
 - [`vercel-composition-patterns`](https://github.com/vercel-labs/agent-skills/tree/main/skills/composition-patterns) - Component composition, code splitting, and server/client boundary patterns for Next.js.
 - [`react-native-patterns`](resources/react-native-patterns/SKILL.md) - Build mobile apps with React Native and Expo — navigation, platform-specific code, performance, and native modules.
+- [`uizze-anti-ui-slop`](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Ground UI decisions in 800,000+ real screens and enforce a pre-ship finish gate.
 
 ### Planning & Architecture
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`vercel-react-view-transitions`](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions) - Implement the View Transitions API in React/Next.js for smooth page and component animations.
 - [`vercel-composition-patterns`](https://github.com/vercel-labs/agent-skills/tree/main/skills/composition-patterns) - Component composition, code splitting, and server/client boundary patterns for Next.js.
 - [`react-native-patterns`](resources/react-native-patterns/SKILL.md) - Build mobile apps with React Native and Expo — navigation, platform-specific code, performance, and native modules.
-- [`uizze-anti-ui-slop`](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Ground UI decisions in 800,000+ real screens and enforce a pre-ship finish gate.
+- [`uizze-anti-ui-slop`](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Ground UI decisions in 800,000+ real screens from [UIZZE](https://uizze.com) and enforce a pre-ship finish gate.
 
 ### Planning & Architecture
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`vercel-react-view-transitions`](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions) - Implement the View Transitions API in React/Next.js for smooth page and component animations.
 - [`vercel-composition-patterns`](https://github.com/vercel-labs/agent-skills/tree/main/skills/composition-patterns) - Component composition, code splitting, and server/client boundary patterns for Next.js.
 - [`react-native-patterns`](resources/react-native-patterns/SKILL.md) - Build mobile apps with React Native and Expo — navigation, platform-specific code, performance, and native modules.
-- [`uizze-anti-ui-slop`](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Ground UI decisions in 800,000+ real screens from [UIZZE](https://uizze.com) and enforce a pre-ship finish gate.
+- [`uizze-anti-ui-slop`](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Ground UI decisions in 800,000+ real screens from [UIZZE](https://uizze.com) and enforce a pre-ship finish gate.
 
 ### Planning & Architecture
 


### PR DESCRIPTION
Adds the public, MIT-licensed UIZZE `anti-ui-slop` skill to Frontend & UI.\n\nThe instruction-only free workflow is Cursor-compatible and teaches the agent to use real interface evidence, make a product-specific design contract, and enforce a pre-ship finish gate.\n\nValidation: confirmed the skill link returns HTTP 200 and the repository ships a standard `SKILL.md`.