### PR TITLE
Add plan-build-judge — Planner → Builder → Judge workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`incident-response`](resources/incident-response/SKILL.md) - Handle production incidents — triage severity, mitigate, communicate status, and write blameless postmortems.
 - [`systematic-debugging`](resources/systematic-debugging/SKILL.md) - Structured debugging methodology — reproduce, isolate, hypothesize, and verify using git bisect, binary search, and logging.
 - [`chatcrystal`](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills) - Local-first memory recall and writeback skills for AI coding sessions via ChatCrystal Core and MCP.
+- [`plan-build-judge`](https://github.com/joker01-01/cursor-plan-build-judge) - Spec-first workflow for complex tasks: Planner writes a testable spec, Builder executes within bounds, Judge reviews against real artifacts instead of self-reported completion. English + Chinese skills included.
 
 ### Infrastructure & DevOps
 


### PR DESCRIPTION
## Summary

Adds [`plan-build-judge`](https://github.com/joker01-01/cursor-plan-build-judge) to **Workflow**.

This is a reusable Cursor skill for complex tasks using an explicit three-stage workflow:

1. **Planner** — turn vague requests into a testable spec
2. **Builder** — implement strictly against the approved spec
3. **Judge** — accept/reject based on verifiable artifacts and acceptance criteria (not Builder self-reports)

## Why it fits

Unlike planning-only or review-only skills, this one connects the full loop and emphasizes evidence-based review. It is intentionally manual (`disable-model-invocation: true`) so it only runs when the user asks for it.

## Details

- Repo: https://github.com/joker01-01/cursor-plan-build-judge
- Skills:
  - `.cursor/skills/plan-build-judge/SKILL.md` (English)
  - `.cursor/skills/plan-build-judge-zh/SKILL.md` (Chinese)
- License: MIT
- Category: Workflow

## Checklist

- [x] Link returns a public repository
- [x] Ships standard `SKILL.md` under `.cursor/skills/`
- [x] Brief description included
- [x] Category specified