### PR TITLE
Add UIZZE anti-UI-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`vercel-react-view-transitions`](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions) - Implement the View Transitions API in React/Next.js for smooth page and component animations.
 - [`vercel-composition-patterns`](https://github.com/vercel-labs/agent-skills/tree/main/skills/composition-patterns) - Component composition, code splitting, and server/client boundary patterns for Next.js.
 - [`react-native-patterns`](resources/react-native-patterns/SKILL.md) - Build mobile apps with React Native and Expo — navigation, platform-specific code, performance, and native modules.
+- [`uizze-anti-ui-slop`](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Ground Cursor in 800,000+ real web and iOS screens, lock a product-specific design contract, and block generic UI at a rendered finish gate.
 
 ### Planning & Architecture
 


### PR DESCRIPTION
Adds one maintained Cursor-compatible skill to Frontend & UI.\n\nWhy it fits:\n- public SKILL.md plus Cursor plugin manifest\n- works with Cursor's agent workflow\n- uses 800,000+ real UI references to create a product-specific design contract\n- includes an implementation manifest and rendered finish gate, rather than acting as a single-prompt wrapper\n- source repository is MIT licensed and has passing security/plugin validation\n\nSkill: https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop\nProduct/docs: https://uizze.com