### PR TITLE
Add pinchen-system-design to Planning & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`anthropic-mcp-builder`](https://github.com/anthropics/skills/tree/main/skills/mcp-builder) - Build Model Context Protocol servers from scratch with tool definitions and transport setup.
 - [`architecture-decision-records`](resources/architecture-decision-records/SKILL.md) - Document technical decisions as ADRs with context, options considered, and rationale.
 - [`database-design`](resources/database-design/SKILL.md) - Design database schemas — tables, relationships, indexes, constraints, and ORM setup.
+- [`pinchen-system-design`](https://github.com/pinchen147/system-design-skill) - Read a repository as its current architecture, run the capacity math, and compare structurally distinct candidates before recommending one.
 
 ### Documentation
 


### PR DESCRIPTION
Adds [`system-design`](https://github.com/pinchen147/system-design-skill) to **Planning & Architecture**.

It reads an existing repository as the current architecture, closes the requirements it cannot recover from the code, derives the capacity envelope, then compares structurally distinct candidates and recommends one with an evidence chain. Outputs an interactive HTML report, a structured `design.json`, and a durable `DESIGN.md` a later session can resume.

Distinct from the neighbouring entries: `improve-codebase-architecture` proposes improvements to existing code, `architecture-decision-records` documents a decision already made, and `database-design` covers schema. This one sits earlier — choosing the architecture, with the capacity math and the trade-offs written down.

Checklist:

- [x] Searched existing entries — no system design entry present
- [x] Format `- [Name](link) - Short description ending with a period.`
- [x] Added to the bottom of an existing category
- [x] Links checked
- [x] One addition in this PR
- [x] Actively maintained, MIT, documented `SKILL.md`
- [x] Works with Cursor via `npx skills add pinchen147/system-design-skill`, and ships as a Claude Code plugin