### PR TITLE
Add God Of Prompt skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`exporting-to-png`](resources/exporting-to-png/SKILL.md) - Export code snippets, diagrams, terminal output, or UI components to PNG images via headless browser or CLI tools.
 - [`generating-images`](resources/generating-images/SKILL.md) - Generate or edit images (icons, logos, blog heroes, OG images, illustrations, mockups) using OpenAI `gpt-image-2`. Supports text-to-image, image-to-image, masked inpainting, and parallel batch jobs.
 - [`prompt-engineering`](resources/prompt-engineering/SKILL.md) - Write effective LLM prompts — system prompts, few-shot examples, chain-of-thought, and structured output.
+- [`gop`](https://github.com/DeAI1227/God-Of-Prompt/tree/main/skills/gop) - Turn rough requirements into six-part XML system prompts, then execute them immediately.
 - [`seo-auditing`](resources/seo-auditing/SKILL.md) - Audit technical SEO — meta tags, structured data, Open Graph, sitemaps, and Core Web Vitals.
 - [`seo-analysis`](https://github.com/nowork-studio/toprank/blob/main/seo/seo-analysis/SKILL.md) - Full SEO audit using Search Console, URL inspection, PageSpeed, technical crawling, metadata checks, schema review, and a prioritized 30-day action plan.
 - [`writing-copy`](resources/writing-copy/SKILL.md) - Write marketing copy for landing pages, CTAs, emails, microcopy, and product descriptions.


### PR DESCRIPTION
## Summary
Adds the GOP skill under Utilities.

## Why it belongs
GOP is an actively maintained, documented SKILL.md workflow that users can copy to .cursor/skills/gop. It transforms a rough requirement into a six-part XML system prompt and then executes it, with output contracts, failure handling, and supporting evidence guidance; it is more than a standalone prompt.

## Checks
- Verified the direct public skill link.
- Added one item in the existing Utilities category.