### PR TITLE
Add claude-skills-pro to Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Skills that harness Cursor's unique agent capabilities — things only an AI ins
 - [`incident-response`](resources/incident-response/SKILL.md) - Handle production incidents — triage severity, mitigate, communicate status, and write blameless postmortems.
 - [`systematic-debugging`](resources/systematic-debugging/SKILL.md) - Structured debugging methodology — reproduce, isolate, hypothesize, and verify using git bisect, binary search, and logging.
 - [`chatcrystal`](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills) - Local-first memory recall and writeback skills for AI coding sessions via ChatCrystal Core and MCP.
+- [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) - 15 engineering-workflow skills (7-dimension code review, root-cause debugging, test generation, behavior-preserving refactor, release notes; 7 free/MIT) that install into Cursor via the open skills installer.
+
 
 ### Infrastructure & DevOps
 


### PR DESCRIPTION
Adds [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) to **Workflow**.

Per the quality standards: actively maintained (commits daily), every skill ships a `SKILL.md`, installs into Cursor via the open skills installer (`npx skills add Hahaknight/claude-skills-pro --agent cursor`), and each skill is a full expert workflow (trigger conditions → procedure → anti-patterns), not a wrapper around a single prompt.

15 skills covering the dev loop — code review, root-cause debugging, test generation, behavior-preserving refactor, release notes; 7 free/MIT. Real output samples: [EXAMPLES.md](https://github.com/Hahaknight/claude-skills-pro/blob/main/EXAMPLES.md)